### PR TITLE
Update AltStore link (uYou 3.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ The best tweak for the YouTube app!
 
 * **Jailbreak:** Add __[https://miro92.com/repo](https://miro92.com/repo)__ to your Cydia/Zebra/Sileo sources and download it from there.
 * **Sideloading (No Jailbreak):** 
-    Download IPA file from here and follow the instructions below to sign and install the app from your computer for one week
+    Download the IPA file from here and follow the instructions below to sign and install the app from your computer for one week
 
-    1. (Option 1) Download IPA file from here and follow the instructions below to sign and install the app from your computer for one week
+    1. (Option 1) Download the IPA file from here and follow the instructions below to sign and install the app from your computer for one week
         | Application | Bundle | Version | uYou | File Type |
         | ------------------ |:---------:|:------:|:------:|:------:|
-        | [YouTube](https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.14.1_uYou_3.0.zip) | com.google.ios.youtube | 18.14.1 | 3.0 | ZIP |
-        | [YouTube](https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.14.1_uYou_3.0.ipa) | com.google.ios.youtube | 18.14.1 | 3.0 | IPA |
+        | [YouTube](https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.29.1_uYou_3.0.1.zip) | com.google.ios.youtube | 18.29.1 | 3.0.1 | ZIP |
+        | [YouTube](https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.29.1_uYou_3.0.1.ipa) | com.google.ios.youtube | 18.29.1 | 3.0.1 | IPA |
         
         
         
-    2. (Option 2) [Optional] You can get a paid subscription from a signing store where you can download the latest uYou directly from your device and have it available for 1 year instead of 7 days. (i.e AppDB Pro).
+    2. (Option 2) [Optional] You can get a paid subscription from a signing store where you can download the latest uYou directly from your device and have it available for 1 year instead of 7 days. (i.e. AppDB Pro).
 
 ## How to Sideload on non-jailbroken devices
 ### Requirements
@@ -31,24 +31,24 @@ The best tweak for the YouTube app!
 ### AltStore
 * Download and install AltServer from [here](https://altstore.io).
 
-* Right click on the AltServer icon with your phone connected and choose "Install Altstore", then the name of your phone. When prompted sign in with your Apple ID. Two-factor Authentication is supported, app-specific passwords are not.
+* Right-click on the AltServer icon with your phone connected and choose "Install Altstore", then the name of your phone. When prompted sign in with your Apple ID. Two-factor Authentication is supported, but app-specific passwords are not.
 
 * Option 1
     * Copy the link below then open it in Safari.
-    * `altstore://install?url=https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.14.1_uYou_3.0.ipa`
+    * `altstore://install?url=https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.29.1_uYou_3.0.1.ipa`
 * Option 2
     * Download the IPA/ZIP file from the link above.
     * Copy the IPA file to your device, using iCloud Drive, Airdrop, or any other method.
     * Open AltStore and navigate to the "My Apps" tab.
-    * Choose the plus sign button locatted in the top right corner and open the IPA file.
-    * When prompted sign in with your Apple ID. Two-factor Authentication is supported, app-specific passwords are not.
+    * Choose the plus sign button located in the top right corner and open the IPA file.
+    * When prompted sign in with your Apple ID. Two-factor Authentication is supported, but app-specific passwords are not.
 
 
 ## Note
 
-* Signing with a non developer account will have the app expire in 7 days, but Altstore automates re-signing as long as it is connected to your PC.
+* Signing with a non-developer account will have the app expire in 7 days, but Altstore automates re-signing as long as it is connected to your PC.
 * The app will not receive Push Notifications.
-* If you're getting **"Error 200"** after signing with AppDB Pro then you need to do change the `Identity type to use for appdb PRO` in the [appdb configuration](https://user-images.githubusercontent.com/52943116/134609634-80155411-ef73-4c5a-89d3-263cf94602dc.PNG) from `Auto` to `Development`. After that, you can set it back to Auto if you want.
+* If you're getting **"Error 200"** after signing with AppDB Pro then you need to change the `Identity type to use for appdb PRO` in the [appdb configuration](https://user-images.githubusercontent.com/52943116/134609634-80155411-ef73-4c5a-89d3-263cf94602dc.PNG) from `Auto` to `Development`. After that, you can set it back to Auto if you want.
 
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The best tweak for the YouTube app!
 
 * Option 1
     * Copy the link below then open it in Safari.
-    * `altstore://install?url=https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_16.42.3_uYou_2.1.ipa`
+    * `altstore://install?url=https://miro92.com/repo/depictions/com.miro.uyou/iPA/YouTube_18.14.1_uYou_3.0.ipa`
 * Option 2
     * Download the IPA/ZIP file from the link above.
     * Copy the IPA file to your device, using iCloud Drive, Airdrop, or any other method.


### PR DESCRIPTION
you forgot to change this, now altstore users can download it on uYou 3.0.1 using this url